### PR TITLE
Set copyright year to current year

### DIFF
--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -55,7 +55,7 @@ function Footer() {
         <div className="text-center font-bold text-sm sm:text-lg">
           <p className="py-2">We do not store uploaded data anywhere.</p>
           <p className="text-gray-300">
-            &copy; Copyright 2022 Compressy
+            &copy; Copyright {new Date().getFullYear()} Compressy
             <span className="px-2">|</span>
             <Link
               href="/terms-privacy/"


### PR DESCRIPTION
Should close #2 
Changes the 'footer.tsx` component to automatically set the copyright year to current year.